### PR TITLE
chore: correct repository URL typo in package.json

### DIFF
--- a/packages/motion-sv/package.json
+++ b/packages/motion-sv/package.json
@@ -6,7 +6,7 @@
 	"description": "Motion for Svelte",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/HanielU/motion-svlte.git"
+		"url": "git+https://github.com/HanielU/motion-svelte.git"
 	},
 	"scripts": {
 		"build": "pnpm package",


### PR DESCRIPTION
Now the NPM link will link to this repo instead of a 404 :) 