### PR TITLE
chore: add homepage to package.json

### DIFF
--- a/packages/motion-sv/package.json
+++ b/packages/motion-sv/package.json
@@ -4,6 +4,7 @@
 	"license": "MIT",
 	"author": "Haniel Ubogu <https://github.com/HanielU>",
 	"description": "Motion for Svelte",
+	"homepage": "https://github.com/hanielu/motion-svelte/tree/main/packages/motion-sv#readme",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/HanielU/motion-svlte.git"


### PR DESCRIPTION
This PR adds a homepage field in package.json. The homepage URL currently shown on NPM is pointing to a README in a different repository that is currently returning a 404 error.